### PR TITLE
Added option for output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following options are available when creating a new ferguson instance with `
 - **wrapJavascript** (default: `false`) - whether to wrap compiled JS in an IIFE.
 - **separateBundles** (default: `false`) - generate separate tags for each asset in a bundle.
 - **html5** (default: `false`) - generate HTML5-compatible tags, e.g. omit the *type* attribute from a `<script>` tag.
+- **outputDir** (default to `dir`) - the path to put and serve the compiled files from.
 
 The following setup is recommended
 

--- a/lib/ferguson.js
+++ b/lib/ferguson.js
@@ -37,6 +37,7 @@ var defaultOptions = {
   , javascriptIIFE: '!function(){%s}();'
   , separateBundles: false
   , html5: false
+  , outputDir: null
 };
 
 /**
@@ -47,8 +48,14 @@ var defaultOptions = {
  */
 
 function Ferguson(dir, options) {
-    this.dir = dir;
+    this.inputDir = dir;
     this.options = utils.mergeDefaults(options, utils.copy(defaultOptions));
+    
+    if(this.options.outputDir === null) {
+        this.options.outputDir = dir;
+    }
+    this.outputDir = this.options.outputDir;
+    
     this.compiledPattern = new RegExp(format('^%s-%s-',
         utils.escapeRegex(this.options.assetPrefix)
       , '[0-9a-f]+?'
@@ -92,7 +99,7 @@ Ferguson.prototype.bind = function (app) {
     this.init();
 
     //Serve existing assets using the express static middleware
-    var staticAssets = express.static(this.dir, {
+    var staticAssets = express.static(this.outputDir, {
         maxAge: this.options.maxAge
     });
     app.use(this.options.servePrefix, staticAssets);
@@ -179,7 +186,7 @@ Ferguson.prototype.bind = function (app) {
 Ferguson.prototype.compileAsset = function (file, callback) {
     var buffers = [], self = this;
     async.eachSeries(file.assets, function (asset, next) {
-        var assetPath = path.join(self.dir, asset.name)
+        var assetPath = path.join(self.inputDir, asset.name)
           , extname = path.extname(asset.name);
         debug('Loading file %s', asset.name);
         fs.readFile(assetPath, function (err, buffer) {
@@ -228,7 +235,7 @@ Ferguson.prototype.compileAsset = function (file, callback) {
         } else {
             buffer = buffers[0];
         }
-        var outputPath = path.join(self.dir, file.path)
+        var outputPath = path.join(self.outputDir, file.path)
           , outputDir = path.dirname(outputPath)
           , extname = path.extname(outputPath);
         if (extname === '.js' && self.options.wrapJavascript) {
@@ -277,7 +284,7 @@ Ferguson.prototype.compileAsset = function (file, callback) {
 Ferguson.prototype.compileAssetSync = function (file) {
     var buffers = [], self = this;
     file.assets.forEach(function (asset) {
-        var assetPath = path.join(self.dir, asset.name)
+        var assetPath = path.join(self.inputDir, asset.name)
           , extname = path.extname(asset.name);
         debug('Loading file %s', asset.name);
         var buffer;
@@ -370,7 +377,7 @@ Ferguson.prototype.indexAssets = function () {
 Ferguson.prototype.getAssets = function () {
     var assets;
     try {
-        assets = utils.walkDirectory(this.dir);
+        assets = utils.walkDirectory(this.inputDir);
     } catch (err) {
         var message = 'Failed to locate assets: ' + err.toString();
         this.emit('error', new Error(message));
@@ -385,7 +392,7 @@ Ferguson.prototype.getAssets = function () {
  */
 
 Ferguson.prototype.hashAssets = function () {
-    var manifestPath = path.join(this.dir, this.options.manifest)
+    var manifestPath = path.join(this.inputDir, this.options.manifest)
       , manifest, outdated = false;
     try {
         manifest = JSON.parse(fs.readFileSync(manifestPath).toString());
@@ -400,7 +407,7 @@ Ferguson.prototype.hashAssets = function () {
             file.hash = manifest[filename].hash;
         } else {
             debug('Hashing file %s', filename);
-            file.hash = utils.hashFile(path.join(this.dir, filename), this.options.hash);
+            file.hash = utils.hashFile(path.join(this.inputDir, filename), this.options.hash);
             outdated = true;
         }
     }
@@ -415,7 +422,7 @@ Ferguson.prototype.hashAssets = function () {
  */
 
 Ferguson.prototype.writeManifest = function () {
-    var manifestPath = path.join(this.dir, this.options.manifest);
+    var manifestPath = path.join(this.inputDir, this.options.manifest);
     try {
         debug('Writing to the manifest file');
         fs.writeFileSync(manifestPath, JSON.stringify(this.assets));
@@ -755,7 +762,7 @@ Ferguson.prototype.defineAsset = function (identifier, options, force) {
                 self.emit('delete', file);
                 delete self.pendingAssets[file];
                 delete self.compiledAssets[file];
-                fs.unlink(path.join(self.dir, file), utils.noop);
+                fs.unlink(path.join(self.outputDir, file), utils.noop);
                 return false;
             }
             return true;
@@ -828,16 +835,16 @@ Ferguson.prototype.watchDirectory = function () {
     for (var file in this.assets) {
         locations.push(path.dirname(file));
     }
-    debug('Watching directory %s for changes', this.dir);
+    debug('Watching directory %s for changes', this.inputDir);
     var self = this;
     this.watchers = utils.stripDuplicates(locations).map(function (dir) {
-        return fs.watch(path.join(self.dir, dir), function (event, filename) {
+        return fs.watch(path.join(self.inputDir, dir), function (event, filename) {
             filename = path.join(dir, filename);
             if (self.isCompiledAsset(filename) || filename === self.options.manifest) {
                 return;
             }
             debug('Detected a change in %s', filename);
-            var filePath = path.join(self.dir, filename)
+            var filePath = path.join(self.inputDir, filename)
               , canonical = filename.toLowerCase();
             try {
                 var stat = fs.statSync(filePath);


### PR DESCRIPTION
This adds an options to change the path the compiled files are written to and are served from. The path from which is read is still the same as before.
It's useful if you don't want to mess your directory with `asset-*`-files up and also want to prohibit that your original files are served.

```javascript
var assets = ferguson('./assets', {
    outputDir: './compiled'
})
```

The manifest-file still remains in the read directory.

This pull request isn't finished yet, I want to add tests to it (but I'm not sure how to deal with that) and there's a bug where old compiled files aren't cleaned up. I don't know if this comes from my changes.